### PR TITLE
Implement auto_format

### DIFF
--- a/R/check_ranges.R
+++ b/R/check_ranges.R
@@ -1,7 +1,8 @@
-check_ranges <- function(d, v) {
+check_ranges <- function(d, format) {
   lex <- bdsreader::bds_lexicon
+  v <- as.integer(substr(format, 1L, 1L))
 
-  e <- catch_cnd(dob <- ymd(extract_field2(d, 20L, format = v)))
+  e <- catch_cnd(dob <- ymd(extract_field2(d, 20L, v = v)))
   if (length(dob) == 0L) {
     message("BDS  20 (",
       lex[lex$bdsnummer == 20, "description"],
@@ -15,7 +16,7 @@ check_ranges <- function(d, v) {
     )
   }
 
-  e <- catch_cnd(dobm <- ymd(extract_field3(d, 63L, format = v)))
+  e <- catch_cnd(dobm <- ymd(extract_field3(d, 63L, v = v)))
   if (!is.null(e)) {
     message("BDS  63 (",
       lex[lex$bdsnummer == 63, "description"],
@@ -23,7 +24,7 @@ check_ranges <- function(d, v) {
     )
   }
 
-  gad <- as.numeric(extract_field2(d, 82L, format = v))
+  gad <- as.numeric(extract_field2(d, 82L, v = v))
   if (is.na(gad)) {
     message("BDS 82 (",
       lex[lex$bdsnummer == 82, "description"],
@@ -37,7 +38,7 @@ check_ranges <- function(d, v) {
     )
     gad <- NA_real_
   }
-  bw <- as.numeric(extract_field2(d, 110L, format = v))
+  bw <- as.numeric(extract_field2(d, 110L, v = v))
   if (is.na(bw)) {
     message("BDS 110 (",
       lex[lex$bdsnummer == 110, "description"],
@@ -51,7 +52,7 @@ check_ranges <- function(d, v) {
     )
   }
 
-  hgtm <- as.numeric(extract_field2(d, 238L, format = v))
+  hgtm <- as.numeric(extract_field2(d, 238L, v = v))
   if (is.na(hgtm)) {
     message("BDS 238 (",
       lex[lex$bdsnummer == 238, "description"],
@@ -65,7 +66,7 @@ check_ranges <- function(d, v) {
     )
   }
 
-  hgtf <- as.numeric(extract_field2(d, 240L, format = v))
+  hgtf <- as.numeric(extract_field2(d, 240L, v = v))
   if (is.na(hgtm)) {
     message("BDS 240 (",
       lex[lex$bdsnummer == 240, "description"],
@@ -96,9 +97,9 @@ check_ranges <- function(d, v) {
     }
 
 
-    hgt <- extract_field(d, 235L, format = v)
-    wgt <- extract_field(d, 245L, format = v)
-    hdc <- extract_field(d, 252L, format = v)
+    hgt <- extract_field(d, 235L, v = v)
+    wgt <- extract_field(d, 245L, v = v)
+    hdc <- extract_field(d, 252L, v = v)
 
     if (all(is.na(hgt))) {
       message("BDS 235 (",

--- a/R/convert_checked_list.R
+++ b/R/convert_checked_list.R
@@ -1,4 +1,6 @@
-convert_checked_list <- function(checked = NULL, append_ddi = FALSE, v = 1) {
+convert_checked_list <- function(checked = NULL, append_ddi = FALSE, format = "1.0") {
+  v <- as.integer(substr(format, 1L, 1L))
+
   d <- checked$data
   switch(v,
          b <- d$ClientGegevens$Elementen,
@@ -15,12 +17,12 @@ convert_checked_list <- function(checked = NULL, append_ddi = FALSE, v = 1) {
   persondata <- tibble(
     id = -1L,
     name = ifelse(length(d$Referentie), as.character(d$Referentie), NA_character_),
-    dob  = extract_dob(d, which = "00", format = v),
-    dobf = extract_dob(d, which = "01", format = v),
-    dobm = extract_dob(d, which = "02", format = v),
+    dob  = extract_dob(d, which = "00", v = v),
+    dobf = extract_dob(d, which = "01", v = v),
+    dobm = extract_dob(d, which = "02", v = v),
     src = src,
     dnr = NA_character_,
-    sex = extract_sex(b, format = v),
+    sex = extract_sex(b, v = v),
 
     # store GA in days and completed weeks
     gad = r$gad,
@@ -28,7 +30,7 @@ convert_checked_list <- function(checked = NULL, append_ddi = FALSE, v = 1) {
 
     # 1 = Nee, volgens BDS 1 = Ja, 2 = Nee
     # FIXME
-    smo = as.numeric(extract_field2(d, 91L, format = v)) - 1L,
+    smo = as.numeric(extract_field2(d, 91L, v = v)) - 1L,
 
     # in grammen, conform BSD
     bw = r$bw,

--- a/R/extract.R
+++ b/R/extract.R
@@ -1,13 +1,13 @@
-extract_dob <- function(d, which = "00", format = 1) {
+extract_dob <- function(d, which = "00", v = 1) {
   if (which == "00") {
-    switch(format,
+    switch(v,
            b <- d$ClientGegevens$Elementen,
            b <- d$ClientGegevens
     )
     if (!length(b)) {
       return(as.Date(NA))
     }
-    switch(format,
+    switch(v,
            dob <- ymd(b[b$Bdsnummer == 20, 2]),
            dob <- ymd(b[b$ElementNummer == 20 & !is.na(b$ElementNummer), 2])
     )
@@ -17,7 +17,7 @@ extract_dob <- function(d, which = "00", format = 1) {
     return(dob)
   }
 
-  switch(format,
+  switch(v,
          p <- d$ClientGegevens$Groepen[[1]],
          p <- d$ClientGegevens$GenesteElementen
   )
@@ -26,13 +26,13 @@ extract_dob <- function(d, which = "00", format = 1) {
   }
   for (i in 1L:length(p)) {
     pp <- p[[i]]
-    switch(format,
+    switch(v,
            parent <- pp[pp$Bdsnummer == 62L, "Waarde"],
            parent <- pp[pp$ElementNummer == 62L, "Waarde"]
            )
     if (is.null(parent)) next
     if (parent == which) {
-      switch(format,
+      switch(v,
              dobp <- ymd(pp[pp$Bdsnummer == 63L, 2L]),
              dobp <- ymd(pp[pp$ElementNummer == 63L, 2L])
       )
@@ -46,12 +46,12 @@ extract_dob <- function(d, which = "00", format = 1) {
 }
 
 
-extract_sex <- function(b, format = 1) {
+extract_sex <- function(b, v = 1) {
 
   if (length(b) == 0L) {
     return(NA_character_)
   }
-  switch(format,
+  switch(v,
          s <- b[b$Bdsnummer == 19L, 2L],
          s <- b[b$ElementNummer == 19L & !is.na(b$ElementNummer), 2L]
   )
@@ -88,13 +88,13 @@ extract_agep_v2 <- function(dob, dobp) {
 }
 
 # For ContactMomenten
-extract_field <- function(d, f = 245L, format = 1) {
-  if (format == 1){
+extract_field <- function(d, f = 245L, v = 1) {
+  if (v == 1){
     z <- d$Contactmomenten[[2L]]
     as.numeric(unlist(lapply(z, function(x, f2 = f) {
       ifelse("Waarde" %in% names(x), x[x$Bdsnummer == f2, "Waarde"], NA)
     })))
-  } else if (format == 2) {
+  } else if (v == 2) {
     z <- d$ContactMomenten[[2L]]
     as.numeric(unlist(lapply(z, function(x, f2 = f) {
       ifelse("Waarde" %in% names(x),
@@ -104,12 +104,12 @@ extract_field <- function(d, f = 245L, format = 1) {
 }
 
 # For ClientGegevens
-extract_field2 <- function(d, f, format = 1) {
-  if (format == 1) {
+extract_field2 <- function(d, f, v = 1) {
+  if (v == 1) {
     b <- d[["ClientGegevens"]][["Elementen"]]
     if (!length(b)) return(NA_real_)
     v <- b[b$Bdsnummer == f, "Waarde"]
-  } else if (format == 2) {
+  } else if (v == 2) {
     b <- d[["ClientGegevens"]]
     if (!length(b)) return(NA_real_)
     v <- b[b$ElementNummer == f & !is.na(b$ElementNummer), "Waarde"]
@@ -118,8 +118,8 @@ extract_field2 <- function(d, f, format = 1) {
 }
 
 # For parent data
-extract_field3 <- function(d, f, which_parent = "02", format = 1) {
-  switch(format,
+extract_field3 <- function(d, f, which_parent = "02", v = 1) {
+  switch(v,
          p <- d[["ClientGegevens"]][["Groepen"]][["Elementen"]],
          p <- d[["ClientGegevens"]][["GenesteElementen"]])
   if (length(p) == 0) {
@@ -127,12 +127,12 @@ extract_field3 <- function(d, f, which_parent = "02", format = 1) {
   }
   for (i in 1L:length(p)) {
     pp <- p[[i]]
-    switch(format,
+    switch(v,
            parent <- pp[pp$Bdsnummer == 62L, "Waarde"],
            parent <- pp[pp$ElementNummer == 62L, "Waarde"])
     if (is.null(parent)) next
     if (parent == which_parent) {
-      switch(format,
+      switch(v,
              return(pp[pp$Bdsnummer == f, 2L]),
              return(pp[pp$ElementNummer == f, 2L]))
     }

--- a/R/set_schema.R
+++ b/R/set_schema.R
@@ -1,27 +1,30 @@
 #' Set the schema from user input
 #'
-#' @param format Integer. JSON schema format number. There are currently two
-#'   schemas supported, formats `1` and `2`.
+#' @param format String. JSON data schema version number. There are currently
+#'   three schemas supported: `1.0`, `1.1` and `2.0`.
 #' @param schema A file name (including path) with the JSON validation schema.
 #'   The `schema` argument overrides `format`. The function extracts the
-#'   character following the string `"_v"` in the base name, and overwrites the
-#'   `format` argument by the integer representation of the found character.
+#'   version number for the basename, and overwrites the
+#'   `format` argument by version number.
 #' @return A list with components `format`, `schema` and `schema_base`.
 #' @examples
-#' set_schema(1)
-#' set_schema(schema = "mydir/myschema_v1.0.json")
+#' set_schema("2.0")
+#'
+#' # for development
+#' set_schema(schema = "mydir/bds_v3.0.json")
 #' @export
-set_schema <- function(format = 2L, schema = NULL) {
+set_schema <- function(format = "1.0", schema = NULL) {
   if (is.null(schema)) {
     schema_base <- switch(as.character(format),
-                          "1" = "bds_v1.0.json",
-                          "2" = "bds_v2.0.json",
-                          "bds_v2.0.json")
+                          "1.0" = "bds_v1.0.json",
+                          "1.1" = "bds_v1.1.json",
+                          "2.0" = "bds_v2.0.json",
+                          "-")
     schema <- system.file("schemas", schema_base, package = "bdsreader", mustWork = TRUE)
   } else {
     # extract format by file name extract
     schema_base <- basename(schema)
-    format <- as.integer(substr(strsplit(schema_base, "_v")[[1]][2], 1, 1))
+    format <- gsub("bds_v(.+).json", "\\1", schema_base)
   }
   list(format = format, schema = schema, schema_base = schema_base)
 }

--- a/R/set_schema.R
+++ b/R/set_schema.R
@@ -20,6 +20,7 @@ set_schema <- function(format = "1.0", schema = NULL) {
                           "1.1" = "bds_v1.1.json",
                           "2.0" = "bds_v2.0.json",
                           "-")
+    if (schema_base == "-") stop("Format ", format, " unknown.")
     schema <- system.file("schemas", schema_base, package = "bdsreader", mustWork = TRUE)
   } else {
     # extract format by file name extract

--- a/R/write_bds.R
+++ b/R/write_bds.R
@@ -63,16 +63,16 @@ write_bds <- function(x = NULL,
   v <- as.integer(substr(format, 1L, 1L))
   if (v == 2L) type <- "numeric"
 
-  # required elements
+  # administrative elements
   bds <- list(
     Format = format,
     OrganisatieCode = as.integer(organisation),
-    ClientGegevens = as_bds_clientdata(x, v, type)
+    Referentie = as_bds_reference(x)
   )
   if (!auto_format) bds$Format <- NULL
 
-  # optional elements
-  bds$Referentie <- as_bds_reference(x)
+  # data elements
+  bds$ClientGegevens <- as_bds_clientdata(x, v, type)
   bds$ContactMomenten <- as_bds_contacts(x, type)
   if (v == 1L) {
     names(bds) <- gsub("ContactMomenten", "Contactmomenten", names(bds))

--- a/R/write_bds.R
+++ b/R/write_bds.R
@@ -9,6 +9,8 @@
 #' artificial birth date `01 Jan 2000` to calculate measurement
 #' dates from age.
 #' @param x      Tibble with an attribute called `person`
+#' @param auto_format Logical. Should a field `Format` be written to the result?
+#' Default is `TRUE`.
 #' @param file   File name. The default (`NULL`) returns the json representation
 #' of the data and does not write to a file.
 #' @param indent Integer. Number of spaces to indent when using
@@ -25,12 +27,13 @@
 #' @seealso [jsonlite::toJSON()]
 #' @examples
 #' fn <- system.file("extdata/bds_v1.0/smocc/Laura_S.json", package = "jamesdemodata")
-#' tgt <- read_bds(fn, format = 1, append_ddi = FALSE)
-#' js1 <- write_bds(tgt, format = 1)
-#' js2 <- write_bds(tgt)
+#' tgt <- read_bds(fn, format = "1.0", append_ddi = FALSE)
+#' js1 <- write_bds(tgt, format = "1.0")
+#' js2 <- write_bds(tgt, format = "2.0")
 #' @export
 write_bds <- function(x = NULL,
-                      format = 2L,
+                      auto_format = TRUE,
+                      format = "v2.0",
                       schema = NULL,
                       file = NULL,
                       organisation = 0L,
@@ -55,26 +58,29 @@ write_bds <- function(x = NULL,
     stop("File ", schema, " not found.")
   }
 
-  # for format 1: distinguish between v1.0 and v1.1
+  # for v = 1: distinguish between v1.0 and v1.1
   type <- ifelse(grepl("v1.1", schema, fixed = TRUE), "numeric", "character")
-  if (format == 2L) type <- "numeric"
+  v <- as.integer(substr(format, 1L, 1L))
+  if (v == 2L) type <- "numeric"
 
   # required elements
   bds <- list(
+    Format = format,
     OrganisatieCode = as.integer(organisation),
-    ClientGegevens = as_bds_clientdata(x, format, type)
+    ClientGegevens = as_bds_clientdata(x, v, type)
   )
+  if (!auto_format) bds$Format <- NULL
 
   # optional elements
   bds$Referentie <- as_bds_reference(x)
   bds$ContactMomenten <- as_bds_contacts(x, type)
-  if (format == 1L) {
+  if (v == 1L) {
     names(bds) <- gsub("ContactMomenten", "Contactmomenten", names(bds))
   }
 
   js <- toJSON(bds, auto_unbox = TRUE, ...)
   js <- gsub("Waarde2", "Waarde", js)
-  if (format == 1L) {
+  if (v == 1L) {
     js <- gsub("ElementNummer", "Bdsnummer", js)
   }
   if (!check) {
@@ -107,8 +113,8 @@ as_bds_reference <- function(tgt) {
   n
 }
 
-as_bds_clientdata <- function(tgt, format, type) {
-  if (format == 2L)
+as_bds_clientdata <- function(tgt, v, type) {
+  if (v == 2L)
     return(as_bds_clientdata_v2(tgt))
   as_bds_clientdata_v1(tgt, type)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -69,117 +69,118 @@ The example file `maria2.json` contains Maria's data coded in JSON format accord
 
 ```
 {
-    "Referentie": "Maria2",
-    "OrganisatieCode": 1234,
-    "ClientGegevens": [
+  "Format": "2.0",
+  "OrganisatieCode": 1234,
+  "Referentie": "Maria2",
+  "ClientGegevens": [
+    {
+      "ElementNummer": 19,
+      "Waarde": "2"
+    },
+    {
+      "ElementNummer": 20,
+      "Waarde": "20181011"
+    },
+    {
+      "ElementNummer": 82,
+      "Waarde": 189
+    },
+    {
+      "ElementNummer": 91,
+      "Waarde": "2"
+    },
+    {
+      "ElementNummer": 110,
+      "Waarde": 990
+    },
+    {
+      "ElementNummer": 238,
+      "Waarde": 1670
+    },
+    {
+      "ElementNummer": 240,
+      "Waarde": 1900
+    },
+    {
+      "GenesteElementen": [
         {
-            "ElementNummer": 19,
-            "Waarde": "2"
+          "ElementNummer": 63,
+          "Waarde": "19950704"
         },
         {
-            "ElementNummer": 20,
-            "Waarde": "20181011"
+          "ElementNummer": 71
         },
         {
-            "ElementNummer": 82,
-            "Waarde": 189
-        },
-        {
-            "ElementNummer": 91,
-            "Waarde": "2"
-        },
-        {
-            "ElementNummer": 110,
-            "Waarde": 990
-        },
-        {
-            "ElementNummer": 238,
-            "Waarde": 1670
-        },
-        {
-            "ElementNummer": 240,
-            "Waarde": 1900
-        },
-        {
-            "GenesteElementen": [
-                {
-                    "ElementNummer": 63,
-                    "Waarde": "19950704"
-                },
-                {
-                    "ElementNummer": 71
-                },
-                {
-                    "ElementNummer": 62,
-                    "Waarde": "01"
-                }
-            ]
-        },
-        {
-            "GenesteElementen": [
-                {
-                    "ElementNummer": 63,
-                    "Waarde": "19901202"
-                },
-                {
-                    "ElementNummer": 71
-                },
-                {
-                    "ElementNummer": 62,
-                    "Waarde": "02"
-                }
-            ]
+          "ElementNummer": 62,
+          "Waarde": "01"
         }
-    ],
-    "ContactMomenten": [
+      ]
+    },
+    {
+      "GenesteElementen": [
         {
-            "Tijdstip": "20181011",
-            "Elementen": [
-                {
-                    "ElementNummer": 245,
-                    "Waarde": 990
-                }
-            ]
+          "ElementNummer": 63,
+          "Waarde": "19901202"
         },
         {
-            "Tijdstip": "20181111",
-            "Elementen": [
-                {
-                    "ElementNummer": 235,
-                    "Waarde": 380
-                },
-                {
-                    "ElementNummer": 245,
-                    "Waarde": 1250
-                },
-                {
-                    "ElementNummer": 252,
-                    "Waarde": 270
-                }
-            ]
+          "ElementNummer": 71
         },
         {
-            "Tijdstip": "20181211",
-            "Elementen": [
-                {
-                    "ElementNummer": 235,
-                    "Waarde": 435
-                },
-                {
-                    "ElementNummer": 245,
-                    "Waarde": 2100
-                },
-                {
-                    "ElementNummer": 252,
-                    "Waarde": 305
-                }
-            ]
+          "ElementNummer": 62,
+          "Waarde": "02"
         }
-    ]
+      ]
+    }
+  ],
+  "ContactMomenten": [
+    {
+      "Tijdstip": "20181011",
+      "Elementen": [
+        {
+          "ElementNummer": 245,
+          "Waarde": 990
+        }
+      ]
+    },
+    {
+      "Tijdstip": "20181111",
+      "Elementen": [
+        {
+          "ElementNummer": 235,
+          "Waarde": 380
+        },
+        {
+          "ElementNummer": 245,
+          "Waarde": 1250
+        },
+        {
+          "ElementNummer": 252,
+          "Waarde": 270
+        }
+      ]
+    },
+    {
+      "Tijdstip": "20181211",
+      "Elementen": [
+        {
+          "ElementNummer": 235,
+          "Waarde": 435
+        },
+        {
+          "ElementNummer": 245,
+          "Waarde": 2100
+        },
+        {
+          "ElementNummer": 252,
+          "Waarde": 305
+        }
+      ]
+    }
+  ]
 }
 ```
 
-JSON is a lightweight format to exchange data between electronic systems. `"ElementNummer"` fields refer to the numbers defined in the Basisdataset JGZ, whereas `"Waarde"` fields contain the value. You can find the exact specification [here](https://www.ncj.nl/themadossiers/informatisering/basisdataset/documentatie/). 
+JSON is a lightweight format to exchange data between electronic systems. `"ElementNummer"` fields refer to the numbers defined in the Basisdataset JGZ, whereas `"Waarde"` fields contain the value. The element numbers and the value correspond to the Basisdataset JGZ, which you can find [here](https://www.ncj.nl/themadossiers/informatisering/basisdataset/documentatie/). 
 
 ### Read and parse input data
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ The `persondata()` function extracts the person-level information:
 ``` r
 persondata(xyz)
 #> # A tibble: 1 x 15
-#>      id name  dobf       dobm       src   dnr   sex      gad    ga   smo    bw
-#>   <int> <chr> <date>     <date>     <chr> <chr> <chr>  <dbl> <dbl> <dbl> <dbl>
-#> 1    -1 Maria 1995-07-04 1990-12-02 0     <NA>  female   189    27     1   990
+#>      id name   dobf       dobm       src   dnr   sex      gad    ga   smo    bw
+#>   <int> <chr>  <date>     <date>     <chr> <chr> <chr>  <dbl> <dbl> <dbl> <dbl>
+#> 1    -1 Maria2 1995-07-04 1990-12-02 1234  <NA>  female   189    27     1   990
 #> # … with 4 more variables: hgtm <dbl>, hgtf <dbl>, agem <dbl>, etn <chr>
 ```
 
@@ -93,119 +93,121 @@ format according to BDS-schema file
 Here’s the contents of the file with the child data:
 
     {
-        "Referentie": "Maria2",
-        "OrganisatieCode": 1234,
-        "ClientGegevens": [
+      "Format": "2.0",
+      "OrganisatieCode": 1234,
+      "Referentie": "Maria2",
+      "ClientGegevens": [
+        {
+          "ElementNummer": 19,
+          "Waarde": "2"
+        },
+        {
+          "ElementNummer": 20,
+          "Waarde": "20181011"
+        },
+        {
+          "ElementNummer": 82,
+          "Waarde": 189
+        },
+        {
+          "ElementNummer": 91,
+          "Waarde": "2"
+        },
+        {
+          "ElementNummer": 110,
+          "Waarde": 990
+        },
+        {
+          "ElementNummer": 238,
+          "Waarde": 1670
+        },
+        {
+          "ElementNummer": 240,
+          "Waarde": 1900
+        },
+        {
+          "GenesteElementen": [
             {
-                "ElementNummer": 19,
-                "Waarde": "2"
+              "ElementNummer": 63,
+              "Waarde": "19950704"
             },
             {
-                "ElementNummer": 20,
-                "Waarde": "20181011"
+              "ElementNummer": 71
             },
             {
-                "ElementNummer": 82,
-                "Waarde": 189
-            },
-            {
-                "ElementNummer": 91,
-                "Waarde": "2"
-            },
-            {
-                "ElementNummer": 110,
-                "Waarde": 990
-            },
-            {
-                "ElementNummer": 238,
-                "Waarde": 1670
-            },
-            {
-                "ElementNummer": 240,
-                "Waarde": 1900
-            },
-            {
-                "GenesteElementen": [
-                    {
-                        "ElementNummer": 63,
-                        "Waarde": "19950704"
-                    },
-                    {
-                        "ElementNummer": 71
-                    },
-                    {
-                        "ElementNummer": 62,
-                        "Waarde": "01"
-                    }
-                ]
-            },
-            {
-                "GenesteElementen": [
-                    {
-                        "ElementNummer": 63,
-                        "Waarde": "19901202"
-                    },
-                    {
-                        "ElementNummer": 71
-                    },
-                    {
-                        "ElementNummer": 62,
-                        "Waarde": "02"
-                    }
-                ]
+              "ElementNummer": 62,
+              "Waarde": "01"
             }
-        ],
-        "ContactMomenten": [
+          ]
+        },
+        {
+          "GenesteElementen": [
             {
-                "Tijdstip": "20181011",
-                "Elementen": [
-                    {
-                        "ElementNummer": 245,
-                        "Waarde": 990
-                    }
-                ]
+              "ElementNummer": 63,
+              "Waarde": "19901202"
             },
             {
-                "Tijdstip": "20181111",
-                "Elementen": [
-                    {
-                        "ElementNummer": 235,
-                        "Waarde": 380
-                    },
-                    {
-                        "ElementNummer": 245,
-                        "Waarde": 1250
-                    },
-                    {
-                        "ElementNummer": 252,
-                        "Waarde": 270
-                    }
-                ]
+              "ElementNummer": 71
             },
             {
-                "Tijdstip": "20181211",
-                "Elementen": [
-                    {
-                        "ElementNummer": 235,
-                        "Waarde": 435
-                    },
-                    {
-                        "ElementNummer": 245,
-                        "Waarde": 2100
-                    },
-                    {
-                        "ElementNummer": 252,
-                        "Waarde": 305
-                    }
-                ]
+              "ElementNummer": 62,
+              "Waarde": "02"
             }
-        ]
+          ]
+        }
+      ],
+      "ContactMomenten": [
+        {
+          "Tijdstip": "20181011",
+          "Elementen": [
+            {
+              "ElementNummer": 245,
+              "Waarde": 990
+            }
+          ]
+        },
+        {
+          "Tijdstip": "20181111",
+          "Elementen": [
+            {
+              "ElementNummer": 235,
+              "Waarde": 380
+            },
+            {
+              "ElementNummer": 245,
+              "Waarde": 1250
+            },
+            {
+              "ElementNummer": 252,
+              "Waarde": 270
+            }
+          ]
+        },
+        {
+          "Tijdstip": "20181211",
+          "Elementen": [
+            {
+              "ElementNummer": 235,
+              "Waarde": 435
+            },
+            {
+              "ElementNummer": 245,
+              "Waarde": 2100
+            },
+            {
+              "ElementNummer": 252,
+              "Waarde": 305
+            }
+          ]
+        }
+      ]
     }
 
 JSON is a lightweight format to exchange data between electronic
 systems. `"ElementNummer"` fields refer to the numbers defined in the
-Basisdataset JGZ, whereas `"Waarde"` fields contain the value. You can
-find the exact specification
+Basisdataset JGZ, whereas `"Waarde"` fields contain the value. The
+element numbers and the value correspond to the Basisdataset JGZ, which
+you can find
 [here](https://www.ncj.nl/themadossiers/informatisering/basisdataset/documentatie/).
 
 ### Read and parse input data

--- a/data-raw/R/maria.R
+++ b/data-raw/R/maria.R
@@ -4,5 +4,7 @@
 fn <- system.file("examples", "maria2.json", package = "bdsreader")
 xyz <- read_bds(fn, format = "2.0")
 
-write_bds(xyz, format = "1.0", auto_format = FALSE, file = "inst/examples/maria1.json", indent = 2)
-write_bds(xyz, format = "2.0", file = "inst/examples/maria2.json", indent = 2)
+write_bds(xyz, format = "1.0", auto_format = FALSE, organisation = 1234L,
+          file = "inst/examples/maria1.json", indent = 2)
+write_bds(xyz, format = "2.0", organisation = 1234L,
+          file = "inst/examples/maria2.json", indent = 2)

--- a/data-raw/R/maria.R
+++ b/data-raw/R/maria.R
@@ -1,0 +1,8 @@
+# update maria1.json and maria2.json
+# careful: This script overwrites maria1.json and maria2.json
+
+fn <- system.file("examples", "maria2.json", package = "bdsreader")
+xyz <- read_bds(fn, format = "2.0")
+
+write_bds(xyz, format = "1.0", auto_format = FALSE, file = "inst/examples/maria1.json", indent = 2)
+write_bds(xyz, format = "2.0", file = "inst/examples/maria2.json", indent = 2)

--- a/inst/examples/maria1.json
+++ b/inst/examples/maria1.json
@@ -1,5 +1,6 @@
 {
-  "OrganisatieCode": 0,
+  "OrganisatieCode": 1234,
+  "Referentie": "Maria2",
   "ClientGegevens": {
     "Elementen": [
       {
@@ -16,7 +17,7 @@
       },
       {
         "Bdsnummer": 91,
-        "Waarde": "1"
+        "Waarde": "2"
       },
       {
         "Bdsnummer": 110,
@@ -64,7 +65,6 @@
       }
     ]
   },
-  "Referentie": "Maria2",
   "Contactmomenten": [
     {
       "Tijdstip": "20181011",

--- a/inst/examples/maria1.json
+++ b/inst/examples/maria1.json
@@ -1,106 +1,114 @@
 {
-   "Referentie":"Maria1",
-   "OrganisatieCode":1234,
-   "ClientGegevens":{
-      "Elementen":[
-         {
-            "Bdsnummer":19,
-            "Waarde":"2"
-         },
-         {
-            "Bdsnummer":20,
-            "Waarde":"20181011"
-         },
-         {
-            "Bdsnummer":82,
-            "Waarde":189
-         },
-         {
-            "Bdsnummer":91,
-            "Waarde":"1"
-         },
-         {
-            "Bdsnummer":110,
-            "Waarde":990
-         },
-         {
-            "Bdsnummer":238,
-            "Waarde":1670
-         },
-         {
-            "Bdsnummer":240,
-            "Waarde":1900
-         }
-      ],
-      "Groepen":[
-         {
-            "Elementen":[
-               {
-                  "Bdsnummer":63,
-                  "Waarde":"19950704"
-               },
-               {
-                  "Bdsnummer":71,
-                  "Waarde":6030
-               },
-               {
-                  "Bdsnummer":62,
-                  "Waarde":"01"
-               }
-            ]
-         },
-         {
-            "Elementen":[
-               {
-                  "Bdsnummer":63,
-                  "Waarde":"19901202"
-               },
-               {
-                  "Bdsnummer":71,
-                  "Waarde":6030
-               },
-               {
-                  "Bdsnummer":62,
-                  "Waarde":"02"
-               }
-            ]
-         }
-      ]
-   },
-   "Contactmomenten":[
+  "OrganisatieCode": 0,
+  "ClientGegevens": {
+    "Elementen": [
       {
-         "Tijdstip":"20181111",
-         "Elementen":[
-            {
-               "Bdsnummer":235,
-               "Waarde":380
-            },
-            {
-               "Bdsnummer":245,
-               "Waarde":1250
-            },
-            {
-               "Bdsnummer":252,
-               "Waarde":270
-            }
-         ]
+        "Bdsnummer": 19,
+        "Waarde": "2"
       },
       {
-         "Tijdstip":"20181211",
-         "Elementen":[
-            {
-               "Bdsnummer":235,
-               "Waarde":435
-            },
-            {
-               "Bdsnummer":245,
-               "Waarde":2100
-            },
-            {
-               "Bdsnummer":252,
-               "Waarde":305
-            }
-         ]
+        "Bdsnummer": 20,
+        "Waarde": "20181011"
+      },
+      {
+        "Bdsnummer": 82,
+        "Waarde": "189"
+      },
+      {
+        "Bdsnummer": 91,
+        "Waarde": "1"
+      },
+      {
+        "Bdsnummer": 110,
+        "Waarde": "990"
+      },
+      {
+        "Bdsnummer": 238,
+        "Waarde": "1670"
+      },
+      {
+        "Bdsnummer": 240,
+        "Waarde": "1900"
       }
-   ]
+    ],
+    "Groepen": [
+      {
+        "Elementen": [
+          {
+            "Bdsnummer": 63,
+            "Waarde": "19950704"
+          },
+          {
+            "Bdsnummer": 71
+          },
+          {
+            "Bdsnummer": 62,
+            "Waarde": "01"
+          }
+        ]
+      },
+      {
+        "Elementen": [
+          {
+            "Bdsnummer": 63,
+            "Waarde": "19901202"
+          },
+          {
+            "Bdsnummer": 71
+          },
+          {
+            "Bdsnummer": 62,
+            "Waarde": "02"
+          }
+        ]
+      }
+    ]
+  },
+  "Referentie": "Maria2",
+  "Contactmomenten": [
+    {
+      "Tijdstip": "20181011",
+      "Elementen": [
+        {
+          "Bdsnummer": 245,
+          "Waarde": "990"
+        }
+      ]
+    },
+    {
+      "Tijdstip": "20181111",
+      "Elementen": [
+        {
+          "Bdsnummer": 235,
+          "Waarde": "380"
+        },
+        {
+          "Bdsnummer": 245,
+          "Waarde": "1250"
+        },
+        {
+          "Bdsnummer": 252,
+          "Waarde": "270"
+        }
+      ]
+    },
+    {
+      "Tijdstip": "20181211",
+      "Elementen": [
+        {
+          "Bdsnummer": 235,
+          "Waarde": "435"
+        },
+        {
+          "Bdsnummer": 245,
+          "Waarde": "2100"
+        },
+        {
+          "Bdsnummer": 252,
+          "Waarde": "305"
+        }
+      ]
+    }
+  ]
 }
+

--- a/inst/examples/maria2.json
+++ b/inst/examples/maria2.json
@@ -1,6 +1,7 @@
 {
   "Format": "2.0",
-  "OrganisatieCode": 0,
+  "OrganisatieCode": 1234,
+  "Referentie": "Maria2",
   "ClientGegevens": [
     {
       "ElementNummer": 19,
@@ -16,7 +17,7 @@
     },
     {
       "ElementNummer": 91,
-      "Waarde": "1"
+      "Waarde": "2"
     },
     {
       "ElementNummer": 110,
@@ -61,7 +62,6 @@
       ]
     }
   ],
-  "Referentie": "Maria2",
   "ContactMomenten": [
     {
       "Tijdstip": "20181011",

--- a/inst/examples/maria2.json
+++ b/inst/examples/maria2.json
@@ -1,109 +1,111 @@
 {
-    "Referentie": "Maria2",
-    "OrganisatieCode": 1234,
-    "ClientGegevens": [
+  "Format": "2.0",
+  "OrganisatieCode": 0,
+  "ClientGegevens": [
+    {
+      "ElementNummer": 19,
+      "Waarde": "2"
+    },
+    {
+      "ElementNummer": 20,
+      "Waarde": "20181011"
+    },
+    {
+      "ElementNummer": 82,
+      "Waarde": 189
+    },
+    {
+      "ElementNummer": 91,
+      "Waarde": "1"
+    },
+    {
+      "ElementNummer": 110,
+      "Waarde": 990
+    },
+    {
+      "ElementNummer": 238,
+      "Waarde": 1670
+    },
+    {
+      "ElementNummer": 240,
+      "Waarde": 1900
+    },
+    {
+      "GenesteElementen": [
         {
-            "ElementNummer": 19,
-            "Waarde": "2"
+          "ElementNummer": 63,
+          "Waarde": "19950704"
         },
         {
-            "ElementNummer": 20,
-            "Waarde": "20181011"
+          "ElementNummer": 71
         },
         {
-            "ElementNummer": 82,
-            "Waarde": 189
-        },
-        {
-            "ElementNummer": 91,
-            "Waarde": "2"
-        },
-        {
-            "ElementNummer": 110,
-            "Waarde": 990
-        },
-        {
-            "ElementNummer": 238,
-            "Waarde": 1670
-        },
-        {
-            "ElementNummer": 240,
-            "Waarde": 1900
-        },
-        {
-            "GenesteElementen": [
-                {
-                    "ElementNummer": 63,
-                    "Waarde": "19950704"
-                },
-                {
-                    "ElementNummer": 71
-                },
-                {
-                    "ElementNummer": 62,
-                    "Waarde": "01"
-                }
-            ]
-        },
-        {
-            "GenesteElementen": [
-                {
-                    "ElementNummer": 63,
-                    "Waarde": "19901202"
-                },
-                {
-                    "ElementNummer": 71
-                },
-                {
-                    "ElementNummer": 62,
-                    "Waarde": "02"
-                }
-            ]
+          "ElementNummer": 62,
+          "Waarde": "01"
         }
-    ],
-    "ContactMomenten": [
+      ]
+    },
+    {
+      "GenesteElementen": [
         {
-            "Tijdstip": "20181011",
-            "Elementen": [
-                {
-                    "ElementNummer": 245,
-                    "Waarde": 990
-                }
-            ]
+          "ElementNummer": 63,
+          "Waarde": "19901202"
         },
         {
-            "Tijdstip": "20181111",
-            "Elementen": [
-                {
-                    "ElementNummer": 235,
-                    "Waarde": 380
-                },
-                {
-                    "ElementNummer": 245,
-                    "Waarde": 1250
-                },
-                {
-                    "ElementNummer": 252,
-                    "Waarde": 270
-                }
-            ]
+          "ElementNummer": 71
         },
         {
-            "Tijdstip": "20181211",
-            "Elementen": [
-                {
-                    "ElementNummer": 235,
-                    "Waarde": 435
-                },
-                {
-                    "ElementNummer": 245,
-                    "Waarde": 2100
-                },
-                {
-                    "ElementNummer": 252,
-                    "Waarde": 305
-                }
-            ]
+          "ElementNummer": 62,
+          "Waarde": "02"
         }
-    ]
+      ]
+    }
+  ],
+  "Referentie": "Maria2",
+  "ContactMomenten": [
+    {
+      "Tijdstip": "20181011",
+      "Elementen": [
+        {
+          "ElementNummer": 245,
+          "Waarde": 990
+        }
+      ]
+    },
+    {
+      "Tijdstip": "20181111",
+      "Elementen": [
+        {
+          "ElementNummer": 235,
+          "Waarde": 380
+        },
+        {
+          "ElementNummer": 245,
+          "Waarde": 1250
+        },
+        {
+          "ElementNummer": 252,
+          "Waarde": 270
+        }
+      ]
+    },
+    {
+      "Tijdstip": "20181211",
+      "Elementen": [
+        {
+          "ElementNummer": 235,
+          "Waarde": 435
+        },
+        {
+          "ElementNummer": 245,
+          "Waarde": 2100
+        },
+        {
+          "ElementNummer": 252,
+          "Waarde": 305
+        }
+      ]
+    }
+  ]
 }
+

--- a/inst/schemas/bds_v1.0.json
+++ b/inst/schemas/bds_v1.0.json
@@ -14,6 +14,12 @@
       "type": "string",
       "pattern": "^(.*)$"
     },
+    "Format": {
+      "title": "Schema version number",
+      "$id": "#/properties/Format",
+      "type": "string",
+      "pattern": "^(\d+\.)?(\d+)$"
+    },
     "OrganisatieCode": {
       "title": "Care organisation code",
       "$id": "#/properties/OrganisatieCode",

--- a/inst/schemas/bds_v1.1.json
+++ b/inst/schemas/bds_v1.1.json
@@ -14,6 +14,12 @@
       "type": "string",
       "pattern": "^(.*)$"
     },
+    "Format": {
+      "title": "Schema version number",
+      "$id": "#/properties/Format",
+      "type": "string",
+      "pattern": "^(\d+\.)?(\d+)$"
+    },
     "OrganisatieCode": {
       "title": "Care organisation code",
       "$id": "#/properties/OrganisatieCode",

--- a/inst/schemas/bds_v2.0.json
+++ b/inst/schemas/bds_v2.0.json
@@ -13,6 +13,12 @@
       "type": "string",
       "pattern": "^(.*)$"
     },
+    "Format": {
+      "title": "Schema version number",
+      "$id": "#/properties/Format",
+      "type": "string",
+      "pattern": "^(\d+\.)?(\d+)$"
+    },
     "OrganisatieCode": {
       "title": "Care organisation code",
       "$id": "#/properties/OrganisatieCode",

--- a/man/read_bds.Rd
+++ b/man/read_bds.Rd
@@ -6,7 +6,8 @@
 \usage{
 read_bds(
   txt = NULL,
-  format = 2L,
+  auto_format = TRUE,
+  format = "1.0",
   schema = NULL,
   append_ddi = FALSE,
   verbose = FALSE,
@@ -16,15 +17,17 @@ read_bds(
 \arguments{
 \item{txt}{A JSON string, URL or file}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{auto_format}{Logical. Should the format be read from the data? Default is \code{TRUE}.}
+
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 
 \item{schema}{A file name (including path) with the JSON validation schema.
 The \code{schema} argument overrides \code{format}. The function extracts the
-character following the string \code{"_v"} in the base name, and overwrites the
-\code{format} argument by the integer representation of the found character.}
+version number for the basename, and overwrites the
+\code{format} argument by version number.}
 
-\item{append_ddi}{Should DDI measures be appended?}
+\item{append_ddi}{Should the DDI responses be appended?}
 
 \item{verbose}{Show verbose output for \code{\link[centile:y2z]{centile::y2z()}}}
 
@@ -42,22 +45,33 @@ Z-scores and transforms the data as a tibble with a \code{person} attribute.
 If \code{txt} is unspecified or \code{NULL}, then the function return will have zero rows.
 
 The \code{format} and \code{schema} arguments specify the format of the JSON input
-data argument \code{txt}. The default is \code{format = 2} expects that the JSON
+data argument \code{txt}. The default is \code{format = "1.0"} expects that the JSON
 input data conform to the schema specified in
-\code{system.file("schemas/bds_v2.0.json", package = "bdsreader")}. The alternative
-is \code{format = 1} expects data coded according to
-\code{system.file("schemas/bds_v1.0.json", package = "bdsreader")}.
-If you erroneously read a JSON file of format 1 with (default) format 2
+\code{system.file("schemas/bds_v1.0.json", package = "bdsreader")}. The alternative
+is \code{format = 2.0} expects data coded according to
+\code{system.file("schemas/bds_v2.0.json", package = "bdsreader")}. For new users,
+we recommend format \code{"2.0"}.
+
+Alternatively, the format can be specified in the JSON data file with an entry
+named \code{Format}. For \code{auto_format == TRUE}, the data specification overrides
+any \code{format} and \code{schema} arguments to the \code{read_bds()} function.
+The schema \code{bds_v2.0.json} schema requires
+the \code{Format} field, so the correct format is automatically set by the data.
+
+If you erroneously read a JSON file of format \code{"1.0"} using format \code{"2.0"}
 you may see \verb{Error in value[[3L]](cond) : object 'dob' not found}. In that
-case specify the \code{format = 1} argument.
+case specify the \code{format = "1.0"} argument.
+Reversely, if you erroneously read a JSON file of format \code{"2.0"} using format
+\code{"1.0"} you may see \verb{.ClientGegevens should be object} and
+\verb{Missing 'ClientGegevens$Groepen'}. In that case, specify \code{format = "2.0"}.
 }
 \examples{
 # Assume that jamesdemodata is installed locally.
 # If not use remotes::install_github("growthcharts/jamesdemodata")
 
-# Read file with input data according to format 2.
+# Read file with input data according to format "2.0".
 data2 <- system.file("extdata/bds_v2.0/smocc/Laura_S.json", package = "jamesdemodata")
-q <- read_bds(data2)
+q <- read_bds(data2, format = "2.0")
 q
 
 # Equivalent, but specifying the built-in schema file bds_v2.0.json
@@ -65,15 +79,19 @@ schema2 <- system.file("schemas/bds_v2.0.json", package = "bdsreader")
 r <- read_bds(data2, schema = schema2)
 identical(q, r)
 
+# Automatic detection of format 2.0
+# s <- read_bds(data2)
+# identical(q, s)
+
 # Reading data with older format (bds_v1.0)
 data1 <- system.file("extdata/bds_v1.0/smocc/Laura_S.json", package = "jamesdemodata")
-s <- read_bds(data1, format = 1)
-s
+t <- read_bds(data1)
+t
 
 # same, but using a built-in schema file
 schema1 <- system.file("schemas/bds_v1.0.json", package = "bdsreader")
-t <- read_bds(data1, schema = schema1)
-identical(s, t)
+u <- read_bds(data1, schema = schema1)
+identical(t, u)
 }
 \seealso{
 \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}, \code{\link[centile:y2z]{centile::y2z()}}

--- a/man/set_schema.Rd
+++ b/man/set_schema.Rd
@@ -4,16 +4,16 @@
 \alias{set_schema}
 \title{Set the schema from user input}
 \usage{
-set_schema(format = 2L, schema = NULL)
+set_schema(format = "1.0", schema = NULL)
 }
 \arguments{
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 
 \item{schema}{A file name (including path) with the JSON validation schema.
 The \code{schema} argument overrides \code{format}. The function extracts the
-character following the string \code{"_v"} in the base name, and overwrites the
-\code{format} argument by the integer representation of the found character.}
+version number for the basename, and overwrites the
+\code{format} argument by version number.}
 }
 \value{
 A list with components \code{format}, \code{schema} and \code{schema_base}.
@@ -22,6 +22,8 @@ A list with components \code{format}, \code{schema} and \code{schema_base}.
 Set the schema from user input
 }
 \examples{
-set_schema(1)
-set_schema(schema = "mydir/myschema_v1.0.json")
+set_schema("2.0")
+
+# for development
+set_schema(schema = "mydir/bds_v3.0.json")
 }

--- a/man/verify.Rd
+++ b/man/verify.Rd
@@ -4,10 +4,15 @@
 \alias{verify}
 \title{Verify validity of incoming JSON data}
 \usage{
-verify(txt, schema, ...)
+verify(txt, auto_format = TRUE, format = "1.0", schema = NULL, ...)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file}
+
+\item{auto_format}{Logical. Should the format be read from the data? Default is \code{TRUE}.}
+
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 
 \item{schema}{A JSON string, URL or file with the JSON validation
 schema.}
@@ -26,7 +31,7 @@ checks the input json for further processing.
 \examples{
 txt <- system.file("extdata/bds_v1.0/smocc/Laura_S.json", package = "jamesdemodata")
 schema <- system.file("schemas/bds_v1.0.json", package = "bdsreader")
-p <- verify(txt, schema)
+p <- verify(txt, schema = schema)
 }
 \seealso{
 \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}

--- a/man/write_bds.Rd
+++ b/man/write_bds.Rd
@@ -6,7 +6,8 @@
 \usage{
 write_bds(
   x = NULL,
-  format = 2L,
+  auto_format = TRUE,
+  format = "v2.0",
   schema = NULL,
   file = NULL,
   organisation = 0L,
@@ -19,13 +20,16 @@ write_bds(
 \arguments{
 \item{x}{Tibble with an attribute called \code{person}}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{auto_format}{Logical. Should a field \code{Format} be written to the result?
+Default is \code{TRUE}.}
+
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 
 \item{schema}{A file name (including path) with the JSON validation schema.
 The \code{schema} argument overrides \code{format}. The function extracts the
-character following the string \code{"_v"} in the base name, and overwrites the
-\code{format} argument by the integer representation of the found character.}
+version number for the basename, and overwrites the
+\code{format} argument by version number.}
 
 \item{file}{File name. The default (\code{NULL}) returns the json representation
 of the data and does not write to a file.}
@@ -59,9 +63,9 @@ dates from age.
 }
 \examples{
 fn <- system.file("extdata/bds_v1.0/smocc/Laura_S.json", package = "jamesdemodata")
-tgt <- read_bds(fn, format = 1, append_ddi = FALSE)
-js1 <- write_bds(tgt, format = 1)
-js2 <- write_bds(tgt)
+tgt <- read_bds(fn, format = "1.0", append_ddi = FALSE)
+js1 <- write_bds(tgt, format = "1.0")
+js2 <- write_bds(tgt, format = "2.0")
 }
 \seealso{
 \code{\link[jsonlite:fromJSON]{jsonlite::toJSON()}}

--- a/tests/testthat/test-bds_schema.R
+++ b/tests/testthat/test-bds_schema.R
@@ -5,9 +5,10 @@ schemas <- c(system.file("schemas/bds_v1.0.json", package = "bdsreader", mustWor
 paths <-   c("bds_v1.0",
              "bds_v2.0")
 
-for (format in 1:2) {
-  schema <- schemas[format]
-  path <- paths[format]
+for (format in c("1.0", "2.0")) {
+  v <- as.integer(substr(format, 1L, 1L))
+  schema <- schemas[v]
+  path <- paths[v]
 
   jtf <- system.file("extdata", path, "test",
                      paste0("test", 1:25, ".json"),
@@ -37,7 +38,7 @@ for (format in 1:2) {
     )
   })
 
-  if (format == 1) {
+  if (v == 1) {
     test_that("test3.json (missing OrganisatieCode) MESS", {
       expect_message(
         read_bds(jtf[3], schema = schema),
@@ -53,7 +54,7 @@ for (format in 1:2) {
     })
   }
 
-  if (format == 2) {  # other messages are OK
+  if (v == 2) {  # other messages are OK
     test_that("test3.json (missing OrganisatieCode) MESS", {
       expect_silent(
         read_bds(jtf[3], schema = schema)
@@ -78,7 +79,7 @@ for (format in 1:2) {
     )
   })
 
-  if (format == 1) {
+  if (v == 1) {
     test_that("test7.json (Missing Referentie & OrganisatieCode) MESS", {
       expect_message(
         read_bds(jtf[7], schema = schema),
@@ -88,7 +89,7 @@ for (format in 1:2) {
   }
 
 
-  if (format == 2) {  # v2.0: silent is OK
+  if (v == 2) {  # v2.0: silent is OK
     test_that("test7.json (Missing Referentie & OrganisatieCode) MESS", {
       expect_silent(
         read_bds(jtf[7], schema = schema))
@@ -103,7 +104,7 @@ for (format in 1:2) {
     )
   })
 
-  if (format == 1) {
+  if (v == 1) {
     test_that("test9.json (Bdsnummer 19 missing) MESS", {
       expect_message(
         read_bds(jtf[9], schema = schema),
@@ -112,7 +113,7 @@ for (format in 1:2) {
     })
   }
 
-  if (format == 2) {  #  v2.0: Silent is OK
+  if (v == 2) {  #  v2.0: Silent is OK
     test_that("test9.json (Bdsnummer 19 missing) MESS", {
       expect_silent(
         read_bds(jtf[9], schema = schema))
@@ -120,7 +121,7 @@ for (format in 1:2) {
   }
 
 
-  if (format == 1) {
+  if (v == 1) {
     test_that("test10.json (Bdsnummer 20 missing) MESS", {
       expect_message(
         read_bds(jtf[10], schema = schema),
@@ -129,7 +130,7 @@ for (format in 1:2) {
     })
   }
 
-  if (format == 2) {  # v2.0: Other message OK
+  if (v == 2) {  # v2.0: Other message OK
     test_that("test10.json (Bdsnummer 20 missing) MESS", {
       expect_message(
         read_bds(jtf[10], schema = schema),
@@ -159,13 +160,13 @@ for (format in 1:2) {
     expect_error(read_bds(jtf[14], schema = schema), "premature EOF")
   })
 
-  if (format == 1) {
+  if (v == 1) {
     test_that("test15.json (Bdsnummer 62 numeric) MESS", {
       expect_message(read_bds(jtf[15], schema = schema))
     })
   }
 
-  if (format == 2) {  # v2.0: silent is OK
+  if (v == 2) {  # v2.0: silent is OK
     test_that("test15.json (Bdsnummer 62 numeric) MESS", {
       expect_silent(read_bds(jtf[15], schema = schema))
     })
@@ -179,7 +180,7 @@ for (format in 1:2) {
     expect_silent(read_bds(jtf[17], schema = schema))
   })
 
-  if (format == 1) {
+  if (v == 1) {
     test_that("test18.json (Bdsnummer 91 numeric) MESS", {
       expect_message(
         read_bds(jtf[18], schema = schema),
@@ -188,7 +189,7 @@ for (format in 1:2) {
     })
   }
 
-  if (format == 2) {  # v2.0: Silent is OK
+  if (v == 2) {  # v2.0: Silent is OK
     test_that("test18.json (Bdsnummer 91 numeric) MESS", {
       expect_silent(
         read_bds(jtf[18], schema = schema)
@@ -206,7 +207,7 @@ for (format in 1:2) {
     )
   })
 
-  if (format == 1) {
+  if (v == 1) {
     test_that("test21.json (minimal data) MESS", {
       expect_message(read_bds(jtf[21], schema = schema),
                      "Missing 'Contactmomenten'",
@@ -215,7 +216,7 @@ for (format in 1:2) {
     })
   }
 
-  if (format == 2) {  # v2.0: Other messages
+  if (v == 2) {  # v2.0: Other messages
     test_that("test21.json (minimal data) MESS", {
       expect_message(read_bds(jtf[21], schema = schema))
     })

--- a/tests/testthat/test-write_bds.R
+++ b/tests/testthat/test-write_bds.R
@@ -4,10 +4,11 @@ schemas <- c(system.file("schemas/bds_v1.0.json", package = "bdsreader", mustWor
              system.file("schemas/bds_v2.0.json", package = "bdsreader", mustWork = TRUE))
 paths <-   c("bds_v1.0",
              "bds_v2.0")
+format <- "1.0"
 
-format <- 2
-schema <- schemas[format]
-path <- paths[format]
+v <- as.integer(substr(format, 1L, 1L))
+schema <- schemas[v]
+path <- paths[v]
 
 jtf <- system.file("extdata", path, "test",
                    paste0("test", 1:25, ".json"),
@@ -15,13 +16,12 @@ jtf <- system.file("extdata", path, "test",
 
 d <- jsonlite::fromJSON(jtf[11])
 d[["ClientGegevens"]][["GenesteElementen"]][[8]]
-tgt <- read_bds(jtf[11], format = 2)
+tgt <- read_bds(jtf[11], format = format)
 js <- write_bds(tgt, format = format, org = 10, check = TRUE)
 d2 <- jsonlite::fromJSON(js)
 d2[["ClientGegevens"]][["GenesteElementen"]][[9]]
 identical(d[["ClientGegevens"]][["GenesteElementen"]][[8]], d2[["ClientGegevens"]][["GenesteElementen"]][[8]])
 
 # save to file
-js <- prettify(js)
-writeLines(text = js, con = "temp.json")
-
+# js <- prettify(js)
+# writeLines(text = js, con = "temp.json")


### PR DESCRIPTION
This PR defines a new facility `auto_format` that reads the schema version number from the new JSON data field `"Format"`. Using auto_format bypasses the need to specify the `format` or `schema` arguments. 

- `read_bds()` gives priority to `"Format"` field in the data, if there is one
- `write_bds()` will automatically add the `"Format"` field (this can be circumvent by setting `auto_format = FALSE`)
- The default format changed back to "1.0", so early users of data format "1.0" need not change their request or data format.
- Using the `"Format"` is recommended for versions "2.0" and higher.

Format "1.0" is supported for backward compatibility. New development will take version "2.0" as starting point.
