### PR TITLE
Convert BDS 71 (parental birth country) from integer to string

### DIFF
--- a/R/convert_checked_list_3.R
+++ b/R/convert_checked_list_3.R
@@ -76,17 +76,15 @@ convert_checked_list_3 <- function(bds, ds) {
       first()
   }
 
-  if (all(hasName(bds, c("number", "nest", "code")))) {
+  if (all(hasName(bds, c("character", "nest", "code")))) {
     psn[["blbf"]] <-
       filter(bds, bds == 71L & .data$nest == 62L & .data$code == "01") %>%
-      pull("number") %>%
-      first() %>%
-      as.integer()
+      pull("character") %>%
+      first()
     psn[["blbm"]] <-
       filter(bds, bds == 71L & .data$nest == 62L & .data$code == "02") %>%
-      pull("number") %>%
-      first() %>%
-      as.integer()
+      pull("character") %>%
+      first()
   }
 
   if (all(hasName(bds, c("category", "nest", "code")))) {

--- a/R/convert_raw_df.R
+++ b/R/convert_raw_df.R
@@ -97,8 +97,8 @@ set_type <- function(bds) {
                 948, 949, 950, 953, 954, 972, 980, 982, 984,
                 998, 1001, 1278)
   date <- c(20, 63)
-  number <- c(71, 82, 110, 235, 238, 240, 245, 252, 471)
-  character <- c(16)
+  number <- c(82, 110, 235, 238, 240, 245, 252, 471)
+  character <- c(16, 71)
 
   type <- rep(NA_character_, length(bds))
   type[bds %in% category] <- "category"

--- a/data-raw/R/bds_lexicon.R
+++ b/data-raw/R/bds_lexicon.R
@@ -46,7 +46,7 @@ create_bds_lexicon <- function() {
       "one of: 01, 02, 03, 04, 05, 06, 07, 08, 98",
       "yyyymmdd",
       "one of: 01, 02, 03, 04, 05, 06, 07, 08, 98, 00",
-      "4-digit code",
+      "string with 4-digits",
       "in days",
       "one of: 1, 2, 99",
       "in grammes",

--- a/inst/examples/test.json
+++ b/inst/examples/test.json
@@ -96,7 +96,7 @@
         },
         {
           "bdsNumber": 71,
-          "value": 6030
+          "value": "6030"
         }
       ]
     },
@@ -110,7 +110,7 @@
         },
         {
           "bdsNumber": 71,
-          "value": 6030
+          "value": "6030"
         },
         {
           "bdsNumber": 66,

--- a/inst/schemas/bds_v3.0.json
+++ b/inst/schemas/bds_v3.0.json
@@ -97,7 +97,7 @@
           {
             "properties": {
               "bdsNumber": {
-                "const": 16
+                "enum": [16, 71]
               },
               "value": {
                 "type": "string",
@@ -135,18 +135,6 @@
                 "const": 66
               },
               "value": {"enum": ["01", "02", "03", "04", "05", "06", "07", "08", "09", "98", "00"]}
-            }
-          },
-          {
-            "properties": {
-              "bdsNumber": {
-                "const": 71
-              },
-              "value": {
-                "type": "number",
-                "minimum": 1000,
-                "maximum": 9999
-              }
             }
           },
           {


### PR DESCRIPTION
The definition of the BDS field 71 is "alphanumeric". In `bdsreader` this definition was interpreted that the data specification should be integer (pre-24.0) or numeric (24.0). Neither is correct. The usual interpretation is that BDS 71 is a string with four digits. For example, "0123" should be read into R as character, and not be converted to integer or number.

This PR corrects this error. Changes made: 

- `schemas/bds_v3.0.json` definition change (we don't care about pre v3.0 schemas)
- alterations in the reading routines 
- alterations in the example data

As a result definition and `blbf` and `blbm` fields are now read as character.